### PR TITLE
Use --fill flag for gh pr create in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -18,5 +18,5 @@ git add .
 git commit -m "$version $build"
 git new-br
 git push -u origin
-gh pr create 
+gh pr create --fill
 gh pr merge --auto --merge --delete-branch


### PR DESCRIPTION
## Summary
- `update.sh` の `gh pr create` が引数なしのため対話的にタイトル・本文を尋ねてきて自動化が止まる問題を修正
- `--fill` フラグで直前のコミットメッセージから PR タイトル・本文を自動で埋めるようにした

## Test plan
- [ ] 次回 `update.sh` を実行したときに `gh pr create` が対話プロンプトを出さず通過すること
- [ ] 作成された PR のタイトルが直前コミットのメッセージ (`"$version $build"`) になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)