### PR TITLE
Pass branch name explicitly in update.sh to avoid gh prompt

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -17,7 +17,6 @@ git add .
 
 git commit -m "$version $build"
 git new-br
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git push -u origin "$branch"
-gh pr create --fill --head "$branch"
+git push -u origin
+gh pr create --fill --head "$(git rev-parse --abbrev-ref HEAD)"
 gh pr merge --auto --merge --delete-branch

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,7 @@ git add .
 
 git commit -m "$version $build"
 git new-br
-git push -u origin
-gh pr create --fill
+branch="$(git rev-parse --abbrev-ref HEAD)"
+git push -u origin "$branch"
+gh pr create --fill --head "$branch"
 gh pr merge --auto --merge --delete-branch


### PR DESCRIPTION
## Summary
- `gh pr create --fill` でも、ブランチが push されたと gh が認識できないと "Where should we push the '<branch>' branch?" の対話プロンプトが出る問題を修正
- `git push -u origin` (refspec なし) は環境によっては upstream を正しく張れず、gh が「未 push のブランチ」と判定してプロンプトを出していたのが原因
- 現在のブランチ名を `git rev-parse --abbrev-ref HEAD` で取得し、`git push` と `gh pr create --head` の両方に明示的に渡すように変更

## Test plan
- [ ] 次回 `update.sh` を実行したとき、`gh pr create` が "Where should we push" プロンプトを出さず PR が作られること
- [ ] 作成された PR の head ブランチが期待どおりであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)